### PR TITLE
URL Cleanup

### DIFF
--- a/src/RabbitMQ.Client/pkg/RabbitMQ.Client.nuspec
+++ b/src/RabbitMQ.Client/pkg/RabbitMQ.Client.nuspec
@@ -6,8 +6,8 @@
     <title>RabbitMQ.Client</title>
     <authors>The RabbitMQ Team</authors>
     <owners>Pivotal</owners>
-    <projectUrl>http://www.rabbitmq.com/dotnet.html</projectUrl>
-	<licenseUrl>http://www.rabbitmq.com/dotnet.html</licenseUrl>
+    <projectUrl>https://www.rabbitmq.com/dotnet.html</projectUrl>
+	<licenseUrl>https://www.rabbitmq.com/dotnet.html</licenseUrl>
 	<iconUrl>https://en.gravatar.com/userimage/10048884/0ea8846e080980f705da081be53599ce.png?size=100</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The RabbitMQ .NET client is the official client library for C# (and, implicitly, other .NET languages)</description>

--- a/src/RabbitMQ.ServiceModel/pkg/RabbitMQ.ServiceModel.nuspec
+++ b/src/RabbitMQ.ServiceModel/pkg/RabbitMQ.ServiceModel.nuspec
@@ -6,8 +6,8 @@
     <title>RabbitMQ.ServiceModel</title>
     <authors>The RabbitMQ Team</authors>
     <owners>Pivotal</owners>
-    <projectUrl>http://www.rabbitmq.com/dotnet.html</projectUrl>
-	<licenseUrl>http://www.rabbitmq.com/dotnet.html</licenseUrl>
+    <projectUrl>https://www.rabbitmq.com/dotnet.html</projectUrl>
+	<licenseUrl>https://www.rabbitmq.com/dotnet.html</licenseUrl>
 	<iconUrl>https://en.gravatar.com/userimage/10048884/0ea8846e080980f705da081be53599ce.png?size=100</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A WCF Binding for RabbitMQ.</description>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd (404) with 2 occurrences could not be migrated:  
   ([https](https://schemas.microsoft.com/packaging/2010/07/nuspec.xsd) result AnnotatedConnectException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.rabbitmq.com/dotnet.html with 4 occurrences migrated to:  
  https://www.rabbitmq.com/dotnet.html ([https](https://www.rabbitmq.com/dotnet.html) result 200).